### PR TITLE
Fixed label type name conflict

### DIFF
--- a/lib/prawn/types.yaml
+++ b/lib/prawn/types.yaml
@@ -16,7 +16,7 @@ Avery7160:
     row_gutter: 0
 
 #Avery 7165
-Avery7160:
+Avery7165:
     paper_size: A4
     top_margin: 50
     bottom_margin: 25


### PR DESCRIPTION
Both Avery 7160 and 7165 had "Avery7160" as the key in the types.yaml file. I fixed this.